### PR TITLE
Fix 3

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,10 @@ readme = README.md
 perl = 5.10.1
 Pod::Strip = 0
 
+[Prereqs / TestRequires]
+Test::More  = 0.98 ; subtests fixes
+Test::Needs = 0
+
 [OptionalFeature / Legacy]
 -default = 1
 -description = Legacy (no-arguments) ok_dependencies() invocation

--- a/lib/Test/Dependencies.pm
+++ b/lib/Test/Dependencies.pm
@@ -132,8 +132,9 @@ sub _get_modules_used {
     my ($files) = @_;
     my @modules;
 
+    require Test::Dependencies::Light;
     foreach my $file (sort @$files) {
-        my $ret = get_modules_used_in_file($file);
+        my $ret = Test::Dependencies::Light::get_modules_used_in_file($file);
         if (! defined $ret) {
             die "Could not determine modules used in '$file'";
         }

--- a/t/00-load-basic.t
+++ b/t/00-load-basic.t
@@ -1,9 +1,17 @@
 #!perl
 
-use Test::More;
+use Test::More 0.98;
+use Test::Needs;
 
 use_ok('Test::Dependencies');
 use_ok('Test::Dependencies::Light');
-use_ok('Test::Dependencies::Heavy');
+
+subtest "Heavy Loading" => sub {
+    test_needs + {
+        'B::PerlReq'     => 0,
+        'PerlReq::Utils' => 0,
+    };
+    use_ok('Test::Dependencies::Heavy');
+};
 
 done_testing;

--- a/t/03-empty.t
+++ b/t/03-empty.t
@@ -1,18 +1,19 @@
 #!perl
 
 use Test::Builder::Tester tests => 2;
-use Test::Dependencies;
+require Test::Dependencies;           # must not be 'use' to avoid import + plan set
+require Test::Dependencies::Light;    # has to happen before chdir
 
 chdir "t/data/empty";
 
 test_out("not ok 1 - Missing META.{yml,json} file for dependency checking");
 test_fail(+2);
 test_diag("Use the non-legacy invocation to provide the info");
-ok_dependencies();
+Test::Dependencies::ok_dependencies();
 test_test("empty directory fails to find META.yml");
 
 chdir "../../../t/data/mostly-empty";
 
 test_out("ok 1 - META.yml is present and readable");
-ok_dependencies();
+Test::Dependencies::ok_dependencies();
 test_test("mostly empty directory works just fine");

--- a/t/05-dependencies-heavy.t
+++ b/t/05-dependencies-heavy.t
@@ -1,8 +1,12 @@
 #!perl
 
+use Test::Needs + { 'B::PerlReq' => 0, 'PerlReq::Utils' => 0 };
+
 # yay bootstrap!
-use Test::Dependencies exclude => [qw/Test::Dependencies
-   ExtUtils::MakeMaker  CPAN::Meta::Requirements Module::Metadata /],
-    style => 'heavy';
+use Test::Dependencies exclude => [
+    qw/Test::Dependencies
+      ExtUtils::MakeMaker  CPAN::Meta::Requirements Module::Metadata /
+  ],
+  style => 'heavy';
 
 ok_dependencies();

--- a/t/data/mostly-empty/META.yml
+++ b/t/data/mostly-empty/META.yml
@@ -1,0 +1,4 @@
+author: Zev Benjamin <zev@cpan.com>
+requires: ~
+version: 1.0
+name: Mostly::Empty

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,6 +1,0 @@
-#!perl
-
-use Test::More;
-eval "use Test::Pod::Coverage 1.04";
-plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage" if $@;
-all_pod_coverage_ok();

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,0 @@
-#!perl
-
-use Test::More;
-eval "use Test::Pod 1.14";
-plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
-all_pod_files_ok();


### PR DESCRIPTION
This PR Series fixes all observed defects showing in #3. Each Commit explains why it needed fixed and what was broken. 

Closes #3 

---

Pod.t and Pod-Coverage.t I strongly recommend against bringing back, but if you _insist_ on having them, ensure that you use the equivalent `dzil` plugins, and do **not** use rewriting tricks to put them in `t/`.

( As downstream vendor, pod tests are killed on sight because they cause non-problems and fail to guard against real problems, which is a bad default )
