### PR TITLE
Add verbose reports

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-Dependencies
 
+0.23    Wed May 17, 2017
+        * Add verbosity in test report. Offending modules will be added to the
+          failed test result message for Used core and non-core module.
+
 0.22    Sat Aug 20, 2016
         * don't run load tests when Test::More is version 1.1.14; it has a bug
           leading to our tests to fail incorrectly (something about plan

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name         = Test-Dependencies
 abstract     = Verify dependencies in META.yml or cpanfile
 author       = Erik Huelsmann <ehuels@gmail.com>
-version      = 0.22
+version      = 0.23
 copyright_holder = Erik Huelsmann
 main_module  = lib/Test/Dependencies.pm
 license      = Perl_5

--- a/lib/Test/Dependencies.pm
+++ b/lib/Test/Dependencies.pm
@@ -322,19 +322,15 @@ sub ok_dependencies {
         next if exists $ignores{$mod} ||  $mod =~ $exclude_re;
 
         my $first_in = Module::CoreList->first_release($mod, $required{$mod});
-        my $result = $first_in <= $min_perl_ver || exists $required{$mod};
-        $tb->ok($result,
+        $tb->ok($first_in <= $min_perl_ver || exists $required{$mod},
                 "Used core module '$mod' in core (since $first_in) "
                 . "before perl $minimum_perl or explicitly required"
-                . ( $_verbose && !$result ? " referred in " . join(', ',@{$used{$mod}}) : "" ))
+                . ( $_verbose ? " referred in " . join(', ',@{$used{$mod}}) : "" ))
             if defined $first_in;
 
-        $result = exists $required{$mod};
-        $tb->ok($result,
+        $tb->ok(exists $required{$mod},
                 "Used non-core module '$mod' in requirements listing"
-                . ( $_verbose && !$result
-                    ? " in " . join(', ',@{$used{$mod}})
-                    : "" ))
+                . ( $_verbose ? " in " . join(', ',@{$used{$mod}}) : "" ))
             unless defined $first_in or $mod =~ $exclude_re;
     }
 }

--- a/lib/Test/Dependencies.pm
+++ b/lib/Test/Dependencies.pm
@@ -322,15 +322,19 @@ sub ok_dependencies {
         next if exists $ignores{$mod} ||  $mod =~ $exclude_re;
 
         my $first_in = Module::CoreList->first_release($mod, $required{$mod});
-        $tb->ok($first_in <= $min_perl_ver || exists $required{$mod},
+        my $result = $first_in <= $min_perl_ver || exists $required{$mod};
+        $tb->ok($result,
                 "Used core module '$mod' in core (since $first_in) "
                 . "before perl $minimum_perl or explicitly required"
-                . ( $_verbose ? " referred in " . join(', ',@{$used{$mod}}) : "" ))
+                . ( $_verbose && !$result ? " referred in " . join(', ',@{$used{$mod}}) : "" ))
             if defined $first_in;
 
-        $tb->ok(exists $required{$mod},
+        $result = exists $required{$mod};
+        $tb->ok($result,
                 "Used non-core module '$mod' in requirements listing"
-                . ( $_verbose ? " in " . join(', ',@{$used{$mod}}) : "" ))
+                . ( $_verbose && !$result
+                    ? " in " . join(', ',@{$used{$mod}})
+                    : "" ))
             unless defined $first_in or $mod =~ $exclude_re;
     }
 }


### PR DESCRIPTION
This add verbosity to Used core and Used non-core failed test by showing the offending modules.
For example:
> Failed test 'Used non-core module 'DBI' in requirements listing in xt/40-dbsetup.t, xt/89-dropdb.t'
