### PR TITLE
Add Verbosity to failed tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-Dependencies
 
+0.23    Wed May 17, 2017
+        * Add verbosity in test report. Offending modules will be added to the
+          failed test result message for Used core and non-core module.
+
 0.22    Sat Aug 20, 2016
         * don't run load tests when Test::More is version 1.1.14; it has a bug
           leading to our tests to fail incorrectly (something about plan

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name         = Test-Dependencies
 abstract     = Verify dependencies in META.yml or cpanfile
 author       = Erik Huelsmann <ehuels@gmail.com>
-version      = 0.22
+version      = 0.23
 copyright_holder = Erik Huelsmann
 main_module  = lib/Test/Dependencies.pm
 license      = Perl_5


### PR DESCRIPTION
This allows failed tests to indicate offending modules for Used core and non-core modules.